### PR TITLE
do not compute swap gain if both new mappings are not in candidates (…

### DIFF
--- a/smatch.py
+++ b/smatch.py
@@ -536,6 +536,8 @@ def get_best_gain(mapping, candidate_mappings, weight_dict, instance_len, cur_ma
     for i, m in enumerate(mapping):
         for j in range(i + 1, len(mapping)):
             m2 = mapping[j]
+            if (m2 not in candidate_mappings[i]) and (m not in candidate_mappings[j]):
+                continue
             # swap operation (i, m) (j, m2) -> (i, m2) (j, m)
             # j starts from i+1, to avoid duplicate swap
             if veryVerbose:

--- a/smatch.py
+++ b/smatch.py
@@ -536,6 +536,8 @@ def get_best_gain(mapping, candidate_mappings, weight_dict, instance_len, cur_ma
     for i, m in enumerate(mapping):
         for j in range(i + 1, len(mapping)):
             m2 = mapping[j]
+            # no need to compute swap gain if both (i, m2) (j, m) are not in candidate mappings
+            # such a swap cannot incur any gains
             if (m2 not in candidate_mappings[i]) and (m not in candidate_mappings[j]):
                 continue
             # swap operation (i, m) (j, m2) -> (i, m2) (j, m)


### PR DESCRIPTION
I only added two lines (539 and 540) that give **3x speed gain**.

When looking for a swap during hill climbing. We can avoid computing the swap gain if none of the swapped mappings is in the candidate mappings. This will not hurt the search since such a mapping can never contribute to a gain in the score. Also, all optimal mapping will still be reachable even if this swap's gain is not computed/considered.

Doing this change makes the algorithm up to **3x** faster for me on AMR2.0 dev. 

This change has never affected the smatch score in my test runs. Also, I can not see a way how it can possibly affect the smatch one way or the other.